### PR TITLE
feat: Skip data set import if it's file/csv

### DIFF
--- a/Scripts/Import-CluedInConfig.ps1
+++ b/Scripts/Import-CluedInConfig.ps1
@@ -244,7 +244,7 @@ foreach ($dataSet in $dataSets) {
     $dataSetObject = $dataSetJson.data.inbound.dataSet
     Write-Host "Processing Data Set: $($dataSetObject.name) ($($dataSetObject.id))" -ForegroundColor 'Cyan'
 
-    if ($dataSetObject.data.inbound.dataSet.dataSource.type -eq 'file') {
+    if ($dataSetObject.dataSource.type -eq 'file') {
         Write-Warning "Importing of 'file' type data sets are not supported. Only endpoints are. Skipping import."
         continue
     }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
- If attempting to import a file type / csv, it will skip as these are not supported.
Work Item ID: AB#35846


## How has it been tested? <!-- Remove if not needed -->


## Release Note <!-- Remove if not needed -->


## Notable Changes <!-- Remove if not needed -->
