### PR TITLE
fix: Include ruleSet on glossary term creation logic for v4.4.0

### DIFF
--- a/Modules/CluedIn.Product.Toolkit/public/New-CluedInGlossaryTerm.ps1
+++ b/Modules/CluedIn.Product.Toolkit/public/New-CluedInGlossaryTerm.ps1
@@ -12,26 +12,38 @@ function New-CluedInGlossaryTerm {
         .PARAMETER GlossaryId
         You can run Get-CluedInGlossary to get the given Id. Which can then be used here.
 
+        .PARAMETER RuleSet
+        (Optional) Rule set for the created glossary term
+
         .EXAMPLE
         PS> New-CluedInGlossaryTerm -Name "Sample Term" -GlossaryId 'f86ffc29-1963-4a70-b9a8-73de5f007a42'
+        PS> New-CluedInGlossaryTerm -Name "Sample Term" -GlossaryId 'f86ffc29-1963-4a70-b9a8-73de5f007a42' -RuleSet $ruleSet
     #>
 
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)][string]$Name,
-        [guid]$GlossaryId
+        [guid]$GlossaryId,
+        [Parameter(Mandatory = $false)][PSCustomObject]$RuleSet
     )
 
     $queryContent = Get-CluedInGQLQuery -OperationName 'createGlossaryTerm'
 
-    $query = @{
-        variables = @{
-            term = @{
-                name = $Name
-                categoryId = $GlossaryId
-            }
+    $variables = @{
+        term = @{
+            name = $Name
+            categoryId = $GlossaryId
         }
-        query = $queryContent
+    }
+
+    if ($PSBoundParameters.ContainsKey('RuleSet') -and $RuleSet)
+    {
+        $variables.ruleSet = $RuleSet
+    }
+
+    $query = @{
+        variables = $variables
+        query     = $queryContent
     }
 
     return Invoke-CluedInGraphQL -Query $query


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#43353](https://dev.azure.com/CluedIn-io/CluedIn/_workitems/edit/43353)


## How has it been tested? <!-- Remove if not needed -->
- Tested creation of glossary term on v4.4.0 environment
- Test creation of glossary term on v4.3.0 environment


## Notable Changes <!-- Remove if not needed -->
- Updated the import script to check, if the env version is v4.4.0, to include ruleSet in the request