### PR TITLE
fix: Remove unwanted properties when creating a clean project

### DIFF
--- a/Modules/CluedIn.Product.Toolkit/public/New-CluedInCleanProject.ps1
+++ b/Modules/CluedIn.Product.Toolkit/public/New-CluedInCleanProject.ps1
@@ -18,6 +18,8 @@ function New-CluedInCleanProject {
         [Parameter(Mandatory)][PSCustomObject]$Object
     )
 
+    removeUnwantedProperties($Object)
+
     $queryContent = Get-CluedInGQLQuery -OperationName 'createNewCleanProject'
 
     $query = @{
@@ -35,4 +37,36 @@ function New-CluedInCleanProject {
     }
 
     return Invoke-CluedInGraphQL -Query $query
+}
+
+function removeUnwantedProperties($Object){
+    # Removing unwanted properties in the JSON object as GQL returns a 400 if they are left in place
+    if($Object.fields.count -gt 0){
+        foreach ($item in $Object.fields) {
+            $item.PSObject.Properties.Remove("__typename")
+            $item.PSObject.Properties.Remove("icon")
+            $item.PSObject.Properties.Remove("displayName")
+        }
+    }
+
+    $Object.condition.PSObject.Properties.Remove("id")
+    $Object.condition.PSObject.Properties.Remove("type")
+    $Object.condition.PSObject.Properties.Remove("value")
+    $Object.condition.PSObject.Properties.Remove("operator")
+    $Object.condition.PSObject.Properties.Remove("objectTypeId")
+    $Object.condition.PSObject.Properties.Remove("field")
+    $Object.condition.PSObject.Properties.Remove("__typename")
+
+    if($Object.condition.rules.count -gt 0){
+        removeUnwantedPropertyRecursivelyFromRules($Object.condition.rules)
+    }
+}
+
+function removeUnwantedPropertyRecursivelyFromRules($ruleArray, $propertyName){
+    foreach ($item in $ruleArray) {
+        $item.PSObject.Properties.Remove("__typename")
+        if($item.rules.count -gt 0){
+            removeUnwantedPropertyRecursivelyFromRules($item.rules)
+        }
+    }
 }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: AB#43868

We are passing unwanted properties to GQL which causes it to return a 400 when creating a clean project

## How has it been tested? <!-- Remove if not needed -->
Manually tested

