### PR TITLE
fix: Fix vocabulary key imports and remove redundant logging

### DIFF
--- a/Modules/CluedIn.Product.Toolkit/public/New-CluedInVocabularyKey.ps1
+++ b/Modules/CluedIn.Product.Toolkit/public/New-CluedInVocabularyKey.ps1
@@ -19,6 +19,7 @@ function New-CluedInVocabularyKey {
         [Parameter(ParameterSetName = 'New')][string]$DisplayName,
         [Parameter(ParameterSetName = 'New')][string]$GroupName,
         [Parameter(ParameterSetName = 'New')][string]$DataType,
+        [Parameter(ParameterSetName = 'New')][string]$Storage,
         [Parameter(ParameterSetName = 'New')][string]$Description,
         [Parameter(ParameterSetName = 'New')][string]$Prefix,
         [Parameter(Mandatory)][guid]$VocabId,
@@ -29,6 +30,7 @@ function New-CluedInVocabularyKey {
         $DisplayName = $Object.displayName
         $GroupName = $Object.groupName
         $DataType = $Object.dataType
+        $Storage = $Object.storage
         $Description = $Object.description
         $Prefix = $Object.name
         $isVisible = $Object.isVisible
@@ -47,6 +49,7 @@ function New-CluedInVocabularyKey {
                 groupName = $GroupName
                 isVisible = $isVisible
                 dataType = $DataType
+                storage = $Storage
                 description = $Description
                 glossaryTermId = $GlossaryTermId
             }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: AB#43868

We were not setting the storage on a vocabulary key when creating it which caused it to set everything to untyped and end up in invalid configurations that would fail the validation checks.

I have also removed some redundant logging 

## How has it been tested? <!-- Remove if not needed -->
Manually tested
