### PR TITLE
fix: Allow the setting of the account display name on an export target

### DIFF
--- a/Modules/CluedIn.Product.Toolkit/GraphQL/3.7.0/createConnection.gql
+++ b/Modules/CluedIn.Product.Toolkit/GraphQL/3.7.0/createConnection.gql
@@ -1,6 +1,14 @@
-mutation createConnection($connectorId: ID, $authInfo: JSON) {
+mutation createConnection(
+  $connectorId: ID
+  $authInfo: JSON
+  $accountDisplay: String
+) {
   inbound {
-    createConnection(connectorId: $connectorId, authInfo: $authInfo) {
+    createConnection(
+      connectorId: $connectorId
+      authInfo: $authInfo
+      accountDisplay: $accountDisplay
+    ) {
       id
       __typename
     }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: AB#44212

We were not passing the accountDisplay in when creating an export target

## How has it been tested? <!-- Remove if not needed -->
Manually tested
