### PR TITLE
feat: Get Vocabulary Key by Name

### DIFF
--- a/Modules/CluedIn.Product.Toolkit/GraphQL/getVocabularyByKeyName.gql
+++ b/Modules/CluedIn.Product.Toolkit/GraphQL/getVocabularyByKeyName.gql
@@ -1,0 +1,75 @@
+query getVocabularyKey($key: String!) {
+  management {
+    id
+    vocabularyPerKey(key: $key) {
+      ...VocabularyKey
+      isVocabularyOwner
+      __typename
+    }
+    __typename
+  }
+}
+
+fragment VocabularyKey on VocabularyKey {
+  displayName
+  vocabularyKeyId
+  vocabularyId
+  name
+  isVisible
+  isCluedInCore
+  isDynamic
+  isProvider
+  isObsolete
+  groupName
+  key
+  storage
+  dataClassificationCode
+  dataType
+  description
+  dataAnnotationsIsPrimaryKey
+  dataAnnotationsIsEditable
+  dataAnnotationsIsNullable
+  dataAnnotationsIsRequired
+  dataAnnotationsMinimumLength
+  dataAnnotationsMaximumLength
+  providerId
+  compositeVocabularyId
+  compositeVocabulary {
+    name
+    displayName
+    dataType
+    __typename
+  }
+  mapsToOtherKeyId
+  glossaryTermId
+  createdAt
+  createdBy
+  mappedKey
+  isValueChangeInsignificant
+  connector {
+    id
+    name
+    about
+    icon
+    type
+    __typename
+  }
+  vocabulary {
+    vocabularyId
+    vocabularyName
+    connector {
+      id
+      name
+      about
+      icon
+      __typename
+    }
+    __typename
+  }
+  author {
+    id
+    username
+    __typename
+  }
+  __typename
+}

--- a/Modules/CluedIn.Product.Toolkit/public/Get-CluedInVocabularyKey.ps1
+++ b/Modules/CluedIn.Product.Toolkit/public/Get-CluedInVocabularyKey.ps1
@@ -26,6 +26,7 @@ function Get-CluedInVocabularyKey {
     [CmdletBinding()]
     param (
         [Parameter(ParameterSetName = 'Id')][guid]$Id,
+        [Parameter(ParameterSetName = 'KeyName')][string]$KeyName = "",
         [Parameter(ParameterSetName = 'Search')][string]$Search = "",
         [Parameter(ParameterSetName = 'All')][switch]$All
     )
@@ -91,6 +92,16 @@ function Get-CluedInVocabularyKey {
                     $result.data.management.vocabularyPerKey = $secondResult.data.management.vocabularyKeys.data[0]
                 }
             }
+        }
+        'KeyName' {
+            Write-Verbose "Getting key by key name"
+            $script:queryContent = Get-CluedInGQLQuery -OperationName 'getVocabularyByKeyName'
+
+            $variables = @{
+                key = $KeyName
+            }
+
+            $result = GetResult
         }
         'All' { $result = SearchAll }
     }

--- a/Modules/CluedIn.Product.Toolkit/public/Import/Import-DataSets.ps1
+++ b/Modules/CluedIn.Product.Toolkit/public/Import/Import-DataSets.ps1
@@ -236,7 +236,7 @@ function Import-DataSets{
             if($null -ne $existingPreProcessingRule){
                 Write-Host "Updating PreProcessingRule: $($preProcessingRule.displayname)" -ForegroundColor 'Cyan'
                 $setPreProcessRuleResult = Set-CluedInPreProcessDataSetRule -Id $existingPreProcessingRule.Id -Configuration $preProcessingRule
-                Check-ImportResult -Result $setCluedInPrProcessRuleResult
+                Check-ImportResult -Result $setPreProcessRuleResult
             } else {
                 # Create
                 Write-Host "Creating PreProcessingRule: $($preProcessingRule.displayname)" -ForegroundColor 'Cyan'

--- a/Modules/CluedIn.Product.Toolkit/public/Import/Import-VocabularyKeys.ps1
+++ b/Modules/CluedIn.Product.Toolkit/public/Import/Import-VocabularyKeys.ps1
@@ -75,11 +75,11 @@ function Import-VocabularyKeys{
 
             Write-Host "Processing Vocab Key: $($key.displayName) ($($key.vocabularyKeyId))" -ForegroundColor 'Cyan'
 
-            $currentVocabularyKeyObjectResult = Get-CluedInVocabularyKey -Search $key.key
+            $currentVocabularyKeyObjectResult = Get-CluedInVocabularyKey -KeyName $key.key
             $currentVocabularyKeyObject = $currentVocabularyKeyObjectResult.data.management.vocabularyPerKey
             
             if ($key.mapsToOtherKeyId) {
-                $mappedKeyId = Get-CluedInVocabularyKey -Search $key.mappedKey.key
+                $mappedKeyId = Get-CluedInVocabularyKey -KeyName $key.mappedKey.key
                 $key.mapsToOtherKeyId = $mappedKeyID ?
                     $mappedKeyId.data.management.vocabularyPerKey.vocabularyKeyId :
                     $null


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: AB#44845

We were not getting the vocabulary by its name and searching for it. So if there was a key called region and a key called regionid depending on what order things were returned from the server we could assume that the region key was the regionid key
