### PR TITLE
feat: Add the account display name when updating the datasource provider definition configuration

### DIFF
--- a/Modules/CluedIn.Product.Toolkit/public/Import/Import-DataSources.ps1
+++ b/Modules/CluedIn.Product.Toolkit/public/Import/Import-DataSources.ps1
@@ -50,8 +50,7 @@ function Import-DataSources{
         $dataSourceId = $exists.id ?? $dataSourceResult.data.inbound.createDataSource.id
 
         Write-Host "Updating Configuration for $($dataSourceObject.name)" -ForegroundColor 'Cyan'
-        $dataSourceObject.connectorConfiguration.id =
-            (Get-CluedInDataSource -Search $dataSourceObject.name).data.inbound.dataSource.connectorConfiguration.id
+        $dataSourceObject.connectorConfiguration.id = (Get-CluedInDataSource -Search $dataSourceObject.name).data.inbound.dataSource.connectorConfiguration.id
         $dataSourceObject.connectorConfiguration.configuration.DataSourceId = $dataSourceId
         $dataSourceConfigResult = Set-CluedInDataSourceConfiguration -Object $dataSourceObject.connectorConfiguration
         Check-ImportResult -Result $dataSourceConfigResult

--- a/Modules/CluedIn.Product.Toolkit/public/Set-CluedInDataSourceConfiguration.ps1
+++ b/Modules/CluedIn.Product.Toolkit/public/Set-CluedInDataSourceConfiguration.ps1
@@ -21,6 +21,7 @@ function Set-CluedInDataSourceConfiguration {
         variables = @{
             connectorConfiguration = @{
                 id = $Object.id
+                accountDisplay = $Object.accountDisplay
                 helperConfiguration = @{
                     EndpointName = $Object.name
                     DataSourceId = $Object.configuration.DataSourceId


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: AB#45556

We were not setting the displayname when updating the DataSourceConfiguration

## How has it been tested? <!-- Remove if not needed -->
Manually tested
