### PR TITLE
feat: Add check to list clean projs only if there are items to import

### DIFF
--- a/Modules/CluedIn.Product.Toolkit/public/Import/Import-CleanProjects.ps1
+++ b/Modules/CluedIn.Product.Toolkit/public/Import/Import-CleanProjects.ps1
@@ -24,6 +24,9 @@ function Import-CleanProjects{
     $cleanProjectsPath = Join-Path -Path $RestorePath -ChildPath 'CleanProjects'
 
     $cleanProjects = Get-ChildItem -Path $cleanProjectsPath -Filter "*.json" -Recurse
+    
+    if ($cleanProjects.count -eq 0) { Write-Verbose "No clean projects, continuing"; return }
+
     $currentCleanProjects = Get-CluedInCleanProjects
     $currentCleanProjectsObject = $currentCleanProjects.data.preparation.allCleanProjects.projects
 


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: AB#58180

When importing clean projects if there were not clean projects in the file to import we still loaded retrieved the list of clean projects before bailing out. This just adds a check for no clean projects to import and bails out early


## How has it been tested? <!-- Remove if not needed -->
Manually tested
